### PR TITLE
Add Claude auto-fix workflow with test-suite validation gate

### DIFF
--- a/.github/workflows/claude-auto-fix.yml
+++ b/.github/workflows/claude-auto-fix.yml
@@ -1,0 +1,120 @@
+name: Claude Auto-Fix Tests
+
+# Failure-remediation loop with a validation gate.
+#
+# The safety model — "Claude proposes, the test suite disposes":
+#   1. Claude reads the failing test output, traces the root cause, and edits code.
+#   2. A Verify step re-runs the FULL test suite.
+#   3. If Verify fails, the job fails — nothing is pushed, no PR is opened.
+#   4. Only a green suite produces a PR, and even then a human reviews/merges.
+#
+# The three guardrails that keep autonomy from becoming chaos:
+#   - Validation gate: the test suite is the success oracle (Verify step below).
+#   - Rollback safety net: the fix lands on a throwaway branch via PR, never on the
+#     base branch directly, so the base is always recoverable.
+#   - Iteration + permission limits: --max-turns caps the loop; --allowedTools gives
+#     Claude the minimum tools needed (run tests, read, edit) and nothing else.
+
+on:
+  # Manual trigger — run it by hand against the current branch.
+  workflow_dispatch:
+
+  # Automatic trigger — fires after the test CI workflow completes. The job-level
+  # `if` below ensures we only act when that run actually FAILED.
+  # Point `workflows` at the name of your test workflow (e.g. "CI" / "Tests").
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+
+permissions:
+  contents: write        # commit the fix to a new branch
+  pull-requests: write   # open the PR
+  id-token: write        # OIDC for the Claude action
+
+jobs:
+  auto-fix:
+    # Run on manual dispatch, or only when the triggering CI run failed.
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'failure'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+
+      - name: Install frontend deps
+        working-directory: fluke-client
+        run: npm ci
+
+      # Record the starting commit so the base branch is always recoverable.
+      - name: Checkpoint (rollback anchor)
+        run: echo "BASE_SHA=$(git rev-parse HEAD)" >> "$GITHUB_ENV"
+
+      - name: Claude Auto-Fix
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: |
+            The test suite is failing. Reproduce it by running the backend tests
+            (`dotnet test`) and the frontend tests (`cd fluke-client && CI=true npm test`).
+            Read the failure output, trace the root cause across files, and make the
+            MINIMAL change required to make the tests pass.
+
+            Hard rules:
+            - Fix the production code, not the tests. Do NOT weaken, skip, or delete
+              assertions to force a green run.
+            - Do not refactor unrelated code.
+            - If you cannot find a safe minimal fix, stop and explain why rather than
+              guessing.
+          # Iteration limit + least-privilege tool allowlist. Claude may run the test
+          # commands, read files, and edit them — nothing else.
+          claude_args: |
+            --max-turns 15
+            --allowedTools "Bash(dotnet:*),Bash(npm:*),Read,Edit"
+
+      # ---- VALIDATION GATE ----
+      # This is the crux: the suite runs AFTER Claude's edit. If it is red, the step
+      # exits non-zero, the job fails, and the "Open PR" step below never runs.
+      - name: Verify fix — backend
+        run: dotnet test
+
+      - name: Verify fix — frontend
+        working-directory: fluke-client
+        env:
+          CI: true
+        run: npm test
+
+      # Reached only when both Verify steps were green.
+      - name: Open PR with verified fix
+        if: success()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if git diff --quiet; then
+            echo "Tests are green and Claude made no changes — nothing to PR."
+            exit 0
+          fi
+          BRANCH="claude/auto-fix-${{ github.run_id }}"
+          git config user.name  "claude-auto-fix[bot]"
+          git config user.email "claude-auto-fix[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git commit -am "fix: auto-fix failing tests (verified green by CI)"
+          git push origin "$BRANCH"
+          gh pr create \
+            --title "Auto-fix: failing tests (verified)" \
+            --body "Automated fix by Claude. The full test suite passed in CI before this PR was opened (validation gate). Base checkpoint: \`${BASE_SHA}\`. Human review required before merge." \
+            --base "${{ github.ref_name }}" \
+            --head "$BRANCH"

--- a/scripts/claude-auto-fix.sh
+++ b/scripts/claude-auto-fix.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+#
+# claude-auto-fix.sh — the validation-gate pattern WITHOUT GitHub.
+#
+# Same safety model as the CI workflow ("Claude proposes, the test suite disposes"),
+# but driven by the headless Claude CLI (`claude -p`). Works locally or in any CI
+# (GitLab, Jenkins, CircleCI, a cron box) — anywhere a shell and `claude` exist.
+#
+# The three guardrails:
+#   - Validation gate : $TEST_CMD is the success oracle. We only stop on green.
+#   - Rollback net    : a git checkpoint is taken up front; if we exhaust the budget
+#                       still red, we `git reset --hard` back to it — no half-fix left.
+#   - Iteration limit : $MAX_ITERATIONS bounds the loop; --max-turns bounds each call.
+#   - Least privilege : --allowedTools restricts Claude to running tests, reading, editing.
+#
+# Usage:
+#   ./scripts/claude-auto-fix.sh
+#   TEST_CMD="cd fluke-client && CI=true npm test" MAX_ITERATIONS=5 ./scripts/claude-auto-fix.sh
+#
+set -euo pipefail
+
+TEST_CMD="${TEST_CMD:-dotnet test}"
+MAX_ITERATIONS="${MAX_ITERATIONS:-3}"
+
+# --- Rollback anchor: refuse to run on a dirty tree so the checkpoint is meaningful.
+if ! git diff --quiet || ! git diff --cached --quiet; then
+  echo "✋ Working tree is dirty. Commit or stash first so rollback is safe." >&2
+  exit 1
+fi
+CHECKPOINT="$(git rev-parse HEAD)"
+echo "📌 Checkpoint: $CHECKPOINT"
+echo "🧪 Gate command: $TEST_CMD"
+
+run_tests() { bash -c "$TEST_CMD"; }
+
+for i in $(seq 1 "$MAX_ITERATIONS"); do
+  echo ""
+  echo "=== Iteration $i / $MAX_ITERATIONS ==="
+
+  if run_tests; then
+    echo "✅ Tests pass — done."
+    exit 0
+  fi
+
+  echo "❌ Tests failing — asking Claude for a minimal fix…"
+  claude -p "The test suite (\`$TEST_CMD\`) is failing. Reproduce it, read the failure
+output, trace the root cause, and make the MINIMAL change required to make the tests
+pass. Fix the production code, not the tests — do NOT weaken, skip, or delete
+assertions to force a green run. Do not refactor unrelated code." \
+    --max-turns 15 \
+    --allowedTools "Bash(dotnet:*),Bash(npm:*),Read,Edit"
+done
+
+# --- Final validation gate after the iteration budget is spent.
+echo ""
+echo "=== Final verification ==="
+if run_tests; then
+  echo "✅ Tests pass after $MAX_ITERATIONS iteration(s)."
+  exit 0
+fi
+
+echo "🚨 Still red after $MAX_ITERATIONS iteration(s) — rolling back to $CHECKPOINT." >&2
+git reset --hard "$CHECKPOINT"
+exit 1


### PR DESCRIPTION
## What

Implements the **validation-gate** pattern for autonomous CI fixing — *"Claude proposes, the test suite disposes."*

### `.github/workflows/claude-auto-fix.yml` (GitHub path)
Runs on manual dispatch or after the test CI workflow fails:
1. **Claude Auto-Fix** — reads failing output, traces root cause, edits the minimal code.
2. **Verify (the gate)** — re-runs the full backend + frontend suite. If red, the job fails here.
3. **Open PR** — only reached when the suite is green; the fix lands on a throwaway branch for human review. The base branch is never touched directly.

### `scripts/claude-auto-fix.sh` (non-GitHub path)
The same loop via the headless `claude` CLI for local use or any non-GitHub CI, with a git checkpoint and `git reset --hard` rollback if the iteration budget is exhausted while still red.

## The three guardrails
- **Validation gate** — the test suite is the success oracle; nothing survives that isn't green.
- **Rollback safety net** — PR-only on GitHub; checkpoint + hard reset in the script.
- **Iteration + permission limits** — `--max-turns` bounds the loop; `--allowedTools` gives least-privilege access (run tests, read, edit).

## Notes
- `workflow_run.workflows: ["CI"]` is a placeholder — point it at the actual test-CI workflow name.
- Uses the existing `CLAUDE_CODE_OAUTH_TOKEN` secret (matches the repo's other workflows).