### PR TITLE
Allow bot-pushed commits to re-trigger Claude review

### DIFF
--- a/.github/workflows/claude-review-approve.yml
+++ b/.github/workflows/claude-review-approve.yml
@@ -54,6 +54,12 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Allow re-review when a bot pushes a commit to the PR (e.g. an @claude
+          # fix lands as github-actions[bot]). Without this the action refuses
+          # bot-initiated runs and the synchronize re-review fails. Kept narrow to
+          # the Actions bot — do NOT use '*', which would let any bot (Dependabot,
+          # etc.) trigger the approve flow.
+          allowed_bots: 'github-actions[bot]'
           prompt: |
             Review pull request #${{ github.event.pull_request.number }} for
             correctness bugs and clear quality problems. Read the diff with


### PR DESCRIPTION
## What
Adds `allowed_bots: 'github-actions[bot]'` to the **Claude Review & Approve** action step.

## Why
`claude-code-action` refuses any run **initiated by a bot actor** unless `allowed_bots` lists it. The job-level `if: user.type == 'User'` only checks the PR *author*, not the *pusher* — so when a bot pushes a commit to a human PR, the `synchronize` re-review is bot-initiated and the action errors out.

Observed on PR #42: an `@claude` fix landed as `github-actions[bot]`, the re-review run **failed** with `Workflow initiated by non-human actor: claude (type: Bot)`, and no updated verdict/approval was posted — even though the code was actually fixed.

## Scope
Narrowed to `github-actions[bot]` deliberately. Not `'*'`, which would let any bot (e.g. Dependabot) trigger the approve flow.

## After merge
A subsequent push to PR #42 should re-review cleanly and approve (the diff is now empty — the duplicate DTO was removed).